### PR TITLE
Added ability to base radius on the edge of displays rather than center. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/CMakeFiles/3.21.0/CMakeCCompiler.cmake
+\build
+\bin
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build/CMakeFiles/3.21.0/CMakeCCompiler.cmake

--- a/src/fsr/fsr_easu.hlsl
+++ b/src/fsr/fsr_easu.hlsl
@@ -41,7 +41,6 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 	AU2 gxy = ARmp8x8(LocalThreadId.x) + AU2(WorkGroupId.x << 4u, WorkGroupId.y << 4u);
 	AU2 groupCentre = AU2((WorkGroupId.x << 4u) + 8u, (WorkGroupId.y << 4u) + 8u);
 	// Offsets the radial selection of the workgroups from the center of the displays to the center of the hmd
-	groupCentreEdit = groupCentre.xy;
 	static uint2 groupCentreEdit = 0;
 	groupCentreEdit = groupCentre.xy;
 	groupCentreEdit.x = groupCentreEdit.x * .5;

--- a/src/fsr/fsr_easu.hlsl
+++ b/src/fsr/fsr_easu.hlsl
@@ -40,8 +40,13 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 	// Do remapping of local xy in workgroup for a more PS-like swizzle pattern.
 	AU2 gxy = ARmp8x8(LocalThreadId.x) + AU2(WorkGroupId.x << 4u, WorkGroupId.y << 4u);
 	AU2 groupCentre = AU2((WorkGroupId.x << 4u) + 8u, (WorkGroupId.y << 4u) + 8u);
-	AU2 dc1 = Centre.xy - groupCentre;
-	AU2 dc2 = Centre.zw - groupCentre;
+	// Offsets the radial selection of the workgroups from the center of the displays to the center of the hmd
+	groupCentreEdit = groupCentre.xy;
+	static uint2 groupCentreEdit = 0;
+	groupCentreEdit = groupCentre.xy;
+	groupCentreEdit.x = groupCentreEdit.x * .5;
+	AU2 dc1 = Centre.xy - groupCentreEdit;
+	AU2 dc2 = Centre.zw - (groupCentre / 1.5);
 	if (dot(dc1, dc1) <= Radius.y || dot(dc2, dc2) <= Radius.y) {
 		// only do the expensive EASU for workgroups inside the given radius
 		Upscale(gxy);

--- a/src/fsr/fsr_rcas.hlsl
+++ b/src/fsr/fsr_rcas.hlsl
@@ -31,8 +31,13 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 	// Do remapping of local xy in workgroup for a more PS-like swizzle pattern.
 	AU2 gxy = ARmp8x8(LocalThreadId.x) + AU2(WorkGroupId.x << 4u, WorkGroupId.y << 4u);
 	AU2 groupCentre = AU2((WorkGroupId.x << 4u) + 8u, (WorkGroupId.y << 4u) + 8u);
-	AU2 dc1 = Centre.xy - groupCentre;
-	AU2 dc2 = Centre.zw - groupCentre;
+	// Offsets the radial selection of the workgroups from the center of the displays to the center of the hmd
+	groupCentreEdit = groupCentre.xy;
+	static uint2 groupCentreEdit = 0;
+	groupCentreEdit = groupCentre.xy;
+	groupCentreEdit.x = groupCentreEdit.x * .5;
+	AU2 dc1 = Centre.xy - groupCentreEdit;
+	AU2 dc2 = Centre.zw - (groupCentre / 1.5);
 	if (dot(dc1, dc1) <= Radius.y || dot(dc2, dc2) <= Radius.y) {
 		// only do RCAS for workgroups inside the given radius
 		Sharpen(gxy);

--- a/src/fsr/fsr_rcas.hlsl
+++ b/src/fsr/fsr_rcas.hlsl
@@ -32,7 +32,6 @@ void main(uint3 LocalThreadId : SV_GroupThreadID, uint3 WorkGroupId : SV_GroupID
 	AU2 gxy = ARmp8x8(LocalThreadId.x) + AU2(WorkGroupId.x << 4u, WorkGroupId.y << 4u);
 	AU2 groupCentre = AU2((WorkGroupId.x << 4u) + 8u, (WorkGroupId.y << 4u) + 8u);
 	// Offsets the radial selection of the workgroups from the center of the displays to the center of the hmd
-	groupCentreEdit = groupCentre.xy;
 	static uint2 groupCentreEdit = 0;
 	groupCentreEdit = groupCentre.xy;
 	groupCentreEdit.x = groupCentreEdit.x * .5;

--- a/src/openvr_mod.cfg
+++ b/src/openvr_mod.cfg
@@ -30,6 +30,8 @@
     // IMPORTANT: if you face issues like the view appearing offset or mismatched
     // between the eyes, turn this optimization off by setting the value to 2.0
     "radius": 0.5,
+    "rcas_radius": 0.5,
+    "center_display": true,
 
     // if enabled, applies a negative LOD bias to texture MIP levels
     // should theoretically improve texture detail in the upscaled image

--- a/src/openvr_mod.cfg
+++ b/src/openvr_mod.cfg
@@ -18,19 +18,20 @@
     // tune sharpness, values range from 0 to 1
     "sharpness": 0.9,
     
-    // Only apply FSR to the given radius around the center of the image.
+    // IMPORTANT: if you face issues like the view appearing offset or mismatched
+    // between the eyes, turn this optimization off by setting the value to 2.0
+    // radius Only applys upscaling to the given radius.
     // Anything outside this radius is upscaled by simple bilinear filtering,
     // which is cheaper and thus saves a bit of performance. Due to the design
     // of current HMD lenses, you can experiment with fairly small radii and may
     // still not see a noticeable difference.
-    // Sensible values probably lie somewhere between [0.2, 1.0]. However, note
-    // that, since the image is not spheric, even a value of 1.0 technically still
-    // skips some pixels in the corner of the image, so if you want to completely
-    // disable this optimization, you can choose a value of 2.
-    // IMPORTANT: if you face issues like the view appearing offset or mismatched
-    // between the eyes, turn this optimization off by setting the value to 2.0
     "radius": 0.5,
+    // rcas_radius only applies sharpening to the given radius.
+    // Anything outside this radius is not sharpened. It it best to set this the same as radius but the option is there. 
     "rcas_radius": 0.5,
+    // When set to true, the center point of the radius will be in the center of the display. This is good for most hmds.
+    // When set to false, the center point of the radius will be at the edges of the display closest to the center of the hmd. Ex. Oculus Quest 2, Pimax on Normal fov (<150) 
+    // This is useful when the center of the display does not align well with the sweetspot. Ex. Pimax on Wide fov (>170)
     "center_display": true,
 
     // if enabled, applies a negative LOD bias to texture MIP levels

--- a/src/postprocess/Config.h
+++ b/src/postprocess/Config.h
@@ -7,10 +7,12 @@ std::string GetDllPath();
 
 struct Config {
 	bool fsrEnabled = false;
+	bool center_display = true;
 	bool applyMIPBias = true;
 	float renderScale = 1.f;
 	float sharpness = 0.75f;
 	float radius = 0.5f;
+	float rcas_radius = 0.5f;
 
 	static Config Load() {
 		Config config;
@@ -21,11 +23,13 @@ struct Config {
 				configFile >> root;
 				Json::Value fsr = root.get("fsr", Json::Value());
 				config.fsrEnabled = fsr.get("enabled", false).asBool();
+				config.center_display = fsr.get("center_display", false).asBool();
 				config.sharpness = fsr.get("sharpness", 1.0).asFloat();
 				if (config.sharpness < 0) config.sharpness = 0;
 				config.renderScale = fsr.get("renderScale", 1.0).asFloat();
 				config.applyMIPBias = fsr.get("applyMIPBias", true).asBool();
 				config.radius = fsr.get("radius", 0.5).asFloat();
+				config.rcas_radius = fsr.get("rcas_radius", 0.5).asFloat();
 			}
 		} catch (...) {
 			Log() << "Could not read config file.\n";

--- a/src/postprocess/PostProcessor.cpp
+++ b/src/postprocess/PostProcessor.cpp
@@ -285,7 +285,7 @@ namespace vr {
 	struct SharpenConstants {
 		AU1 const0[4];
 		AU1 imageCentre[4];
-		AU1 radius[4];
+		AU1 rcas_radius[4];
 	};
 
 	void PostProcessor::PrepareSharpeningResources() {
@@ -297,10 +297,10 @@ namespace vr {
 		constants.imageCentre[1] = constants.imageCentre[3] = outputHeight / 2;
 		constants.imageCentre[0] = textureContainsOnlyOneEye ? outputWidth / 2 : outputWidth / 4;
 		constants.imageCentre[2] = textureContainsOnlyOneEye ? outputWidth / 2 : 3 * outputWidth / 4;
-		constants.radius[0] = 0.5f * Config::Instance().radius * outputHeight;
-		constants.radius[1] = constants.radius[0] * constants.radius[0];
-		constants.radius[2] = outputWidth;
-		constants.radius[3] = outputHeight;
+		constants.rcas_radius[0] = 0.5f * Config::Instance().rcas_radius * outputHeight;
+		constants.rcas_radius[1] = constants.rcas_radius[0] * constants.rcas_radius[0];
+		constants.rcas_radius[2] = outputWidth;
+		constants.rcas_radius[3] = outputHeight;
 		D3D11_BUFFER_DESC bd;
 		bd.Usage = D3D11_USAGE_IMMUTABLE;
 		bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;


### PR DESCRIPTION
- Added the ability to switch from the original center based radius to a radius starting from the center edge of the displays. 
- Separated the upscaling and sharpening radius for individual control of each. (upscaling an even smaller part while sharpening performs part of the bilinear image)
- Added notes and config settings 

I wasn't able to get the upscaling and sharpening if statement in the shaders to pass it's variable outside of it's own if statement so the upscaling and sharpening code is in each if statement. If someone knows how to edit a variable in an if statement and use the edited value outside it might be worth doing that to lower file size and make it easier to read.

This should solve issue #27 


This is my first time doing anything like this so if I apologize if I didn't type this correctly or didn't include key information. 