### PR TITLE
Adding configuration to move FSR radius

### DIFF
--- a/src/openvr_mod.cfg
+++ b/src/openvr_mod.cfg
@@ -31,6 +31,16 @@
     // between the eyes, turn this optimization off by setting the value to 2.0
     "radius": 0.5,
 
+    // This will move the centre of the circle drawn by radius from one side or
+    // another. This can be useful for headsets with canted screens as the
+    // center of the screen will not align with what is directly ahead of you.
+    // Values between [0.0, 1.0] will probably be the range of useful values.
+    // 0 being unchanged, directly in the center of each screen, while 1 will
+    // have the center of the circle directly on the inner edge of the screen.
+    // A value of -1 would place the center of the circle on the outside edge
+    // of each screen, though I do not know how this could be useful.
+    "centreOffset": 0.0,
+
     // if enabled, applies a negative LOD bias to texture MIP levels
     // should theoretically improve texture detail in the upscaled image
     // IMPORTANT: if you experience issues with rendering like disappearing

--- a/src/postprocess/Config.h
+++ b/src/postprocess/Config.h
@@ -11,6 +11,7 @@ struct Config {
 	float renderScale = 1.f;
 	float sharpness = 0.75f;
 	float radius = 0.5f;
+	float centreOffset = 0.f;
 
 	static Config Load() {
 		Config config;
@@ -26,6 +27,7 @@ struct Config {
 				config.renderScale = fsr.get("renderScale", 1.0).asFloat();
 				config.applyMIPBias = fsr.get("applyMIPBias", true).asBool();
 				config.radius = fsr.get("radius", 0.5).asFloat();
+				config.centreOffset = fsr.get("centreOffset", 0.0).asFloat();
 			}
 		} catch (...) {
 			Log() << "Could not read config file.\n";

--- a/src/postprocess/PostProcessor.cpp
+++ b/src/postprocess/PostProcessor.cpp
@@ -222,11 +222,12 @@ namespace vr {
 		CheckResult("Creating FSR upscale shader", device->CreateComputeShader( g_FSRUpscaleShader, sizeof(g_FSRUpscaleShader), nullptr, upscaleShader.GetAddressOf()));
 
 		UpscaleConstants constants;
+		float calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
 		// create shader constants buffers
 		FsrEasuCon(constants.const0, constants.const1, constants.const2, constants.const3, inputWidth, inputHeight, inputWidth, inputHeight, outputWidth, outputHeight);
 		constants.imageCentre[1] = constants.imageCentre[3] = outputHeight / 2;
-		constants.imageCentre[0] = textureContainsOnlyOneEye ? outputWidth / 2 : outputWidth / 4;
-		constants.imageCentre[2] = textureContainsOnlyOneEye ? outputWidth / 2 : 3 * outputWidth / 4;
+		constants.imageCentre[0] = textureContainsOnlyOneEye ? (outputWidth + calculatedCentreOffset) / 2 : (outputWidth + calculatedCentreOffset) / 4;
+		constants.imageCentre[2] = textureContainsOnlyOneEye ? (outputWidth - calculatedCentreOffset) / 2 : (3 * outputWidth - calculatedCentreOffset) / 4;
 		constants.radius[0] = 0.5f * Config::Instance().radius * outputHeight;
 		constants.radius[1] = constants.radius[0] * constants.radius[0];
 		constants.radius[2] = outputWidth;
@@ -292,11 +293,12 @@ namespace vr {
 		CheckResult("Creating rCAS sharpening shader", device->CreateComputeShader( g_FSRSharpenShader, sizeof(g_FSRSharpenShader), nullptr, rCASShader.GetAddressOf()));
 
 		SharpenConstants constants;
+		float calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
 		float sharpness = AClampF1( Config::Instance().sharpness, 0, 1 );
 		FsrRcasCon(constants.const0, 2.f - 2*sharpness);
 		constants.imageCentre[1] = constants.imageCentre[3] = outputHeight / 2;
-		constants.imageCentre[0] = textureContainsOnlyOneEye ? outputWidth / 2 : outputWidth / 4;
-		constants.imageCentre[2] = textureContainsOnlyOneEye ? outputWidth / 2 : 3 * outputWidth / 4;
+		constants.imageCentre[0] = textureContainsOnlyOneEye ? (outputWidth + calculatedCentreOffset) / 2 : (outputWidth + calculatedCentreOffset) / 4;
+		constants.imageCentre[2] = textureContainsOnlyOneEye ? (outputWidth - calculatedCentreOffset) / 2 : (3 * outputWidth - calculatedCentreOffset) / 4;
 		constants.radius[0] = 0.5f * Config::Instance().radius * outputHeight;
 		constants.radius[1] = constants.radius[0] * constants.radius[0];
 		constants.radius[2] = outputWidth;

--- a/src/postprocess/PostProcessor.cpp
+++ b/src/postprocess/PostProcessor.cpp
@@ -222,7 +222,7 @@ namespace vr {
 		CheckResult("Creating FSR upscale shader", device->CreateComputeShader( g_FSRUpscaleShader, sizeof(g_FSRUpscaleShader), nullptr, upscaleShader.GetAddressOf()));
 
 		UpscaleConstants constants;
-		float calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
+		int calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
 		// create shader constants buffers
 		FsrEasuCon(constants.const0, constants.const1, constants.const2, constants.const3, inputWidth, inputHeight, inputWidth, inputHeight, outputWidth, outputHeight);
 		constants.imageCentre[1] = constants.imageCentre[3] = outputHeight / 2;
@@ -293,7 +293,7 @@ namespace vr {
 		CheckResult("Creating rCAS sharpening shader", device->CreateComputeShader( g_FSRSharpenShader, sizeof(g_FSRSharpenShader), nullptr, rCASShader.GetAddressOf()));
 
 		SharpenConstants constants;
-		float calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
+		int calculatedCentreOffset = Config::Instance().centreOffset * outputWidth;
 		float sharpness = AClampF1( Config::Instance().sharpness, 0, 1 );
 		FsrRcasCon(constants.const0, 2.f - 2*sharpness);
 		constants.imageCentre[1] = constants.imageCentre[3] = outputHeight / 2;


### PR DESCRIPTION
These changes address this issue: https://github.com/fholger/openvr_fsr/issues/27
A new property is added, allowing the radius to be moved left and right. 1 will move it to the inside edge for each eye, -1 to the outside edge, and 0 will leave the location unchanged.

This is useful for VR headsets with canted screens, as when you look directly forward, your gaze will not land in the center of each screen. Pimax is an example of this.