### PR TITLE
Cap radius at 2 and sharpness at 1 when adjusting with hotkeys

### DIFF
--- a/src/postprocess/PostProcessor.cpp
+++ b/src/postprocess/PostProcessor.cpp
@@ -686,7 +686,7 @@ namespace vr {
 		}
 
 		if (IsHotkeyActive( Config::Instance().hotkeyIncreaseSharpness )) {
-			Config::Instance().sharpness += 0.05f;
+			Config::Instance().sharpness = min(Config::Instance().sharpness + 0.05f, 1.0f);
 			Log() << "Sharpness is now at " << Config::Instance().sharpness << std::endl;
 			Reset();
 		}
@@ -698,7 +698,7 @@ namespace vr {
 		}
 
 		if (IsHotkeyActive( Config::Instance().hotkeyIncreaseRadius )) {
-			Config::Instance().radius += 0.05f;
+			Config::Instance().radius = min(Config::Instance().radius + 0.05f, 2.0f);
 			Log() << "Sharpening radius is now at " << Config::Instance().radius << std::endl;
 			Reset();
 		}


### PR DESCRIPTION
While spamming hotkeys I accidentally ended up with sharpness at 2.5 or so. Decreasing the value again resulted in no change .. obviously. Felt weird for the hotkey to not do anything. So I capped the values ... for both radius and sharpness